### PR TITLE
fix: modify  repo name in npm packeage resource files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "",
+  "name": "guide",
   "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "",
+  "name": "guide",
   "version": "1.4.0",
   "private": true,
-  "homepage": "https://github.com/sentenz/#readme",
-  "bugs": "https://github.com/sentenz//issues",
+  "homepage": "https://github.com/sentenz/guide#readme",
+  "bugs": "https://github.com/sentenz/guide/issues",
   "author": "Sentenz",
   "license": "Apache License 2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/sentenz/.git"
+    "url": "https://github.com/sentenz/guide.git"
   },
   "scripts": {
     "test": "run-s"


### PR DESCRIPTION
Repository 'https://github.com/sentenz/.git/' not found.
The name of the repository was deleted during a cleanup.