### PR TITLE
feat(convention): create a convention for `spdx`

### DIFF
--- a/.github/workflows/continuous-release.yml
+++ b/.github/workflows/continuous-release.yml
@@ -13,8 +13,7 @@ jobs:
       - name: Checkout Codebase
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.ACCESS_TOKEN }}
-          persist-credentials: false
+          token: ${{ secrets.PAT_RELEASE_TOKEN }}
       - name: Setup Release
         run: |
           make setup-continuous-release

--- a/internal/about/licenses.md
+++ b/internal/about/licenses.md
@@ -2,7 +2,11 @@
 
 Open source licenses grant permission to use, modify, and redistribute licensed software for any purpose, subject to conditions preserving the provenance and openness of the software.
 
-- [1. License Checklist](#1-license-checklist)
+When open source software is copied and redistributed, which is usually permitted by any type of open source license, a number of obligations and prohibitions are imposed on the distributor It is common for recipients of such software to redistribute it in such a way as to create a chain of distributors and recipients who must all comply with the same license obligations.
+
+- [1. License List](#1-license-list)
+  - [1.1. 1.1 SPDX](#11-11-spdx)
+  - [1.2. 1.2 OSADLE](#12-12-osadle)
 - [2. License](#2-license)
   - [2.1. GNU AGPLv3](#21-gnu-agplv3)
   - [2.2. GNU GPLv3](#22-gnu-gplv3)
@@ -18,13 +22,17 @@ Open source licenses grant permission to use, modify, and redistribute licensed 
   - [3.3. Limitations](#33-limitations)
 - [4. References](#4-references)
 
-## 1. License Checklist
+## 1. License List
 
-When open source software is copied and redistributed, which is usually permitted by any type of open source license, a number of obligations and prohibitions are imposed on the distributor. It is common for recipients of such software to redistribute it in such a way as to create a chain of distributors and recipients who must all comply with the same license obligations.
+### 1.1. 1.1 SPDX
 
-However, there has been no common understanding of how these obligations are to be fulfilled in detail, which regularly leads to misunderstandings, conflicts, or litigation.
+The [SPDX License List](https://spdx.org/licenses/) is a list of commonly found licenses and exceptions used in free and open or collaborative software, data, hardware, or documentation.
 
-The [OSADLE License Checklists](https://www.osadl.org/OSADL-Open-Source-License-Checklists.oss-compliance-lists.0.html) provides a common [list](https://www.osadl.org/Access-to-raw-data.oss-compliance-raw-data-access.0.html) of obligations of commonly used open source software that are accepted by distributors and copyright holders and trusted by all members of the distribution chain.
+A generated [dataset](https://github.com/spdx/license-list-data/tree/main/text) of the SPDX license list in text format. See references for more informations on SPDX.
+
+### 1.2. 1.2 OSADLE
+
+ The [OSADLE license checklists](https://www.osadl.org/OSADL-Open-Source-License-Checklists.oss-compliance-lists.0.html) provides a common [list of license in raw data](https://www.osadl.org/Access-to-raw-data.oss-compliance-raw-data-access.0.html) of obligations of commonly used open source software that are accepted by distributors and copyright holders and trusted by all members of the distribution chain.
 
 ## 2. License
 
@@ -208,5 +216,7 @@ Most open source licenses also have limitations that usually disclaim warranty a
 
 ## 4. References
 
+- Sentenz [SPDX convention](../convention/spdx.md) article.
+- Sentenz [license guide](../guideline/license-guide.md) article.
 - Open Source Initiative (OSI) [licenses](https://opensource.org/licenses/category) article.
 - Choose a [licenses](https://choosealicense.com/licenses/) article.

--- a/internal/convention/README.md
+++ b/internal/convention/README.md
@@ -11,3 +11,4 @@ Conventions, standards, and specifications administered by organizations or inst
 - [Material Design](material-design.md)
 - [POSIX](posix.md)
 - [Semantic Versioning](semantic-versioning.md)
+- [SPDX](spdx.md)

--- a/internal/convention/spdx.md
+++ b/internal/convention/spdx.md
@@ -1,0 +1,27 @@
+# SPDX
+
+[Software Package Data Exchange (SPDX)](https://spdx.dev/) is an open standard for communicating software bill of material information, including provenance, components, licenses, copyrights, and security references. SPDX reduces redundant work by providing common formats for organizations, companies and communities to share important data, thereby streamlining and improving compliance, security, and dependability.
+
+The SPDX specification is recognized as the international open standard for security, license compliance, and other software supply chain artifacts as `ISO/IEC 5962:2021`.
+
+- [1. Specification](#1-specification)
+- [2. License List](#2-license-list)
+- [3. References](#3-references)
+
+## 1. Specification
+
+The [SPDX Specification](https://spdx.dev/specifications/) is a standard format for communicating the components, licenses and copyrights associated with software packages.
+
+The SPDX standard helps facilitate compliance with free and open source software licenses by standardizing the way license information is shared across the software supply chain. SPDX reduces redundant work by providing a common format for companies and communities to share important data about software licenses and copyrights, thereby streamlining and improving compliance.
+
+## 2. License List
+
+The [SPDX License List](https://spdx.org/licenses/) is an integral part of the SPDX Specification. The SPDX License List is a list of commonly found licenses and exceptions used in free and open or collaborative software, data, hardware, or documentation. The purpose of the SPDX License List is to enable efficient and reliable identification of licenses and exceptions in an SPDX document, in files in general, source files or objects. The SPDX License List includes a standardized short identifier, full name, vetted license text including matching guidelines markup as appropriate, and a canonical permanent URL for each license and exception.
+
+## 3. References
+
+- Sentenz [about licenses](../about/licenses.md) article.
+- Sentenz [license guide](../guideline/license-guide.md) article.
+- SPDX [tools](https://spdx.dev/tools-community/) article.
+- GitHub [SPDX license list](https://github.com/spdx/license-list-XML) repository.
+- GitHub [SPDX license dataset](https://github.com/spdx/license-list-data) repository.

--- a/internal/guideline/license-guide.md
+++ b/internal/guideline/license-guide.md
@@ -278,4 +278,5 @@ trivy fs --format json --security-checks license --severity UNKNOWN,LOW,MEDIUM,H
 
 ## 4. References
 
-- Sentenz [about license](../about/licenses.md) article.
+- Sentenz [SPDX convention](../convention/spdx.md) article.
+- Sentenz [about licenses](../about/licenses.md) article.


### PR DESCRIPTION
[Software Package Data Exchange (SPDX)](https://spdx.dev/) is an open standard for communicating software bill of material information, including provenance, components, licenses, copyrights, and security references. SPDX reduces redundant work by providing common formats for organizations, companies and communities to share important data, thereby streamlining and improving compliance, security, and dependability.